### PR TITLE
Add 'controllerAs' parameter to Component annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,16 @@ MyService.$inject = ['$q', '$http'];
 
 ### Component
 
-The `@Component` annotation transforms a class into a directive, where the class becomes the directive's controller and the `controllerAs` property is the name of the class:
+The `@Component` annotation transforms a class into a directive, where the class becomes the directive's controller and the `controllerAs` property is the name of the class.
+
+You could also set the name of controller used for component template using `controllerAs` parameter. It could be very handy in case you wrap your Angular 1.x directives with `@Component` decorator and don't want to change every template.
 
 ```js
 let myModule = Module('my-component-module', []);
 
 @Component({ 
 	selector : 'my-component',
+	controllerAs : 'vm',
 	bind : { 'myAttrA' : '=', 'myAttrB' : '&' }
 })
 @Template({ url : '/path/to/template.html' })
@@ -124,7 +127,7 @@ angular.module('my-component-module', [
 	return {
 		restrict : 'E',
 		controller : MyComponentCtrl,
-		controllerAs : 'MyComponentCtrl',
+		controllerAs : 'vm',
 		templateUrl : '/path/to/template.html',
 		link: MyComponentCtrl.link,
 		scope : {

--- a/dist/annotations/component.js
+++ b/dist/annotations/component.js
@@ -13,7 +13,7 @@ var Component = function Component(options) {
 		if (!options.selector) throw new Error('Must provide a selector');
 		var info = (0, _utilParseComponentSelector.parseComponentSelector)(options.selector);
 
-		(0, _utilDecorateDirective.decorateDirective)(t, info.name, info.type, options.bind);
+		(0, _utilDecorateDirective.decorateDirective)(t, info.name, info.type, options.bind, options.controllerAs);
 
 		if (info.type !== 'E') {
 			throw new Error('Components must be elements. Maybe you meant Decorator?');

--- a/dist/annotations/component.js
+++ b/dist/annotations/component.js
@@ -4,16 +4,16 @@ Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _decorateDirective = require('../util/decorate-directive');
+var _utilDecorateDirective = require('../util/decorate-directive');
 
-var _parseComponentSelector = require('../util/parse-component-selector');
+var _utilParseComponentSelector = require('../util/parse-component-selector');
 
 var Component = function Component(options) {
 	return function (t) {
 		if (!options.selector) throw new Error('Must provide a selector');
-		var info = _parseComponentSelector.parseComponentSelector(options.selector);
+		var info = (0, _utilParseComponentSelector.parseComponentSelector)(options.selector);
 
-		_decorateDirective.decorateDirective(t, info.name, info.type, options.bind);
+		(0, _utilDecorateDirective.decorateDirective)(t, info.name, info.type, options.bind);
 
 		if (info.type !== 'E') {
 			throw new Error('Components must be elements. Maybe you meant Decorator?');

--- a/dist/annotations/component.spec.js
+++ b/dist/annotations/component.spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Component = require('./component');
+var _component = require('./component');
 
-var _chai = require('../util/tests');
+var _utilTests = require('../util/tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _utilTests2 = _interopRequireDefault(_utilTests);
 
 describe('@Component annotation', function () {
 	it('should decorate a class with the $provider and $component metadata', function () {
@@ -18,7 +18,7 @@ describe('@Component annotation', function () {
 			}
 
 			var _MyClass = MyClass;
-			MyClass = _Component.Component({ selector: 'my-component' })(MyClass) || MyClass;
+			MyClass = (0, _component.Component)({ selector: 'my-component' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -33,7 +33,7 @@ describe('@Component annotation', function () {
 			}
 
 			var _MyClass2 = MyClass;
-			MyClass = _Component.Component({ selector: 'my-component' })(MyClass) || MyClass;
+			MyClass = (0, _component.Component)({ selector: 'my-component' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -52,7 +52,7 @@ describe('@Component annotation', function () {
 					}
 
 					var _MyClass3 = MyClass;
-					MyClass = _Component.Component({ selector: '[my-attr]' })(MyClass) || MyClass;
+					MyClass = (0, _component.Component)({ selector: '[my-attr]' })(MyClass) || MyClass;
 					return MyClass;
 				})();
 			})();
@@ -68,7 +68,7 @@ describe('@Component annotation', function () {
 					}
 
 					var _MyClass4 = MyClass;
-					MyClass = _Component.Component({ selector: '.my-class' })(MyClass) || MyClass;
+					MyClass = (0, _component.Component)({ selector: '.my-class' })(MyClass) || MyClass;
 					return MyClass;
 				})();
 			})();
@@ -87,9 +87,9 @@ describe('@Component annotation', function () {
 			}
 
 			var _MyClass5 = MyClass;
-			MyClass = _Component.Component({
+			MyClass = (0, _component.Component)({
 				selector: 'my-component',
-				bind: { myAttr: '@' }
+				bind: { 'myAttr': '@' }
 			})(MyClass) || MyClass;
 			return MyClass;
 		})();

--- a/dist/annotations/controller.js
+++ b/dist/annotations/controller.js
@@ -1,25 +1,25 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _Module = require('../module/module');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate = require('../util/annotate');
+var _moduleModule = require('../module/module');
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var Controller = function Controller(t) {
-	_annotate2['default'](t, '$provider', {
+	(0, _utilAnnotate2['default'])(t, '$provider', {
 		name: t.name,
 		type: 'controller'
 	});
 };
 
 exports.Controller = Controller;
-_Module.Module.registerProvider('controller', function (provider, module) {
+_moduleModule.Module.registerProvider('controller', function (provider, module) {
 	module.controller(provider.$provider.name, provider);
 });

--- a/dist/annotations/controller.spec.js
+++ b/dist/annotations/controller.spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _sinon = require('../util/tests');
+var _utilTests = require('../util/tests');
 
-var _Controller = require('./controller');
+var _controller = require('./controller');
 
-var _Module = require('../module/module');
+var _moduleModule = require('../module/module');
 
 describe('@Controller annotation', function () {
 	it('should decorate a class with $provider meta data', function () {
@@ -18,7 +18,7 @@ describe('@Controller annotation', function () {
 			}
 
 			var _MyController = MyController;
-			MyController = _Controller.Controller(MyController) || MyController;
+			MyController = (0, _controller.Controller)(MyController) || MyController;
 			return MyController;
 		})();
 
@@ -28,7 +28,7 @@ describe('@Controller annotation', function () {
 	});
 
 	it('should register a controller parser with the Module class', function () {
-		var parser = _Module.Module.getParser('controller');
+		var parser = _moduleModule.Module.getParser('controller');
 
 		parser.should.exist;
 	});
@@ -40,15 +40,15 @@ describe('@Controller annotation', function () {
 			}
 
 			var _MyController2 = MyController;
-			MyController = _Controller.Controller(MyController) || MyController;
+			MyController = (0, _controller.Controller)(MyController) || MyController;
 			return MyController;
 		})();
 
 		var module = {
-			controller: _sinon.sinon.spy()
+			controller: _utilTests.sinon.spy()
 		};
 
-		var parser = _Module.Module.getParser('controller');
+		var parser = _moduleModule.Module.getParser('controller');
 
 		parser(MyController, module);
 
@@ -67,7 +67,7 @@ describe('@Controller annotation', function () {
 			}
 
 			var _MyController3 = MyController;
-			MyController = _Controller.Controller(MyController) || MyController;
+			MyController = (0, _controller.Controller)(MyController) || MyController;
 			return MyController;
 		})();
 
@@ -83,7 +83,7 @@ describe('@Controller annotation', function () {
 			_inherits(NewController, _MyController4);
 
 			var _NewController = NewController;
-			NewController = _Controller.Controller(NewController) || NewController;
+			NewController = (0, _controller.Controller)(NewController) || NewController;
 			return NewController;
 		})(MyController);
 

--- a/dist/annotations/decorator.js
+++ b/dist/annotations/decorator.js
@@ -4,16 +4,16 @@ Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _decorateDirective = require('../util/decorate-directive');
+var _utilDecorateDirective = require('../util/decorate-directive');
 
-var _parseComponentSelector = require('../util/parse-component-selector');
+var _utilParseComponentSelector = require('../util/parse-component-selector');
 
 var Decorator = function Decorator(options) {
 	return function (t) {
 		if (!options.selector) throw new Error('Must provide a selector');
-		var info = _parseComponentSelector.parseComponentSelector(options.selector);
+		var info = (0, _utilParseComponentSelector.parseComponentSelector)(options.selector);
 
-		_decorateDirective.decorateDirective(t, info.name, info.type, options.bind);
+		(0, _utilDecorateDirective.decorateDirective)(t, info.name, info.type, options.bind);
 
 		if (info.type === 'E') {
 			throw new Error('Decorators cannot be elements. Perhaps you meant Component?');

--- a/dist/annotations/factory.js
+++ b/dist/annotations/factory.js
@@ -1,31 +1,30 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
-var _bind = Function.prototype.bind;
-
-var _toConsumableArray = function (arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
+var _bind = Function.prototype.bind;
 
-var _Module = require('../module/module');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate = require('../util/annotate');
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _moduleModule = require('../module/module');
+
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var type = 'factory';
 
 var Factory = function Factory(name) {
 	return function (t) {
-		_annotate2['default'](t, '$provider', { name: name, type: type });
+		(0, _utilAnnotate2['default'])(t, '$provider', { name: name, type: type });
 	};
 };
 
 exports.Factory = Factory;
-_Module.Module.registerProvider(type, function (provider, module) {
+_moduleModule.Module.registerProvider(type, function (provider, module) {
 	var create = provider.create || function (dependencies) {
 		for (var _len = arguments.length, params = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
 			params[_key - 1] = arguments[_key];

--- a/dist/annotations/factory.spec.js
+++ b/dist/annotations/factory.spec.js
@@ -2,13 +2,13 @@
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Factory = require('./factory');
+var _factory = require('./factory');
 
-var _Module = require('../module/module');
+var _moduleModule = require('../module/module');
 
-var _sinon = require('../util/tests');
+var _utilTests = require('../util/tests');
 
 describe('@Factory Annotation', function () {
 	it('should decorate a class with $provider meta information', function () {
@@ -18,7 +18,7 @@ describe('@Factory Annotation', function () {
 			}
 
 			var _ExampleClass = ExampleClass;
-			ExampleClass = _Factory.Factory('MyFactory')(ExampleClass) || ExampleClass;
+			ExampleClass = (0, _factory.Factory)('MyFactory')(ExampleClass) || ExampleClass;
 			return ExampleClass;
 		})();
 
@@ -32,8 +32,8 @@ describe('@Factory Annotation', function () {
 		    module = undefined;
 
 		beforeEach(function () {
-			module = { factory: _sinon.sinon.spy() };
-			parser = _Module.Module.getParser('factory');
+			module = { factory: _utilTests.sinon.spy() };
+			parser = _moduleModule.Module.getParser('factory');
 		});
 
 		it('should register itself with Module', function () {
@@ -57,7 +57,7 @@ describe('@Factory Annotation', function () {
 					}
 				}]);
 
-				ExampleClass = _Factory.Factory('MyFactory')(ExampleClass) || ExampleClass;
+				ExampleClass = (0, _factory.Factory)('MyFactory')(ExampleClass) || ExampleClass;
 				return ExampleClass;
 			})();
 
@@ -88,7 +88,7 @@ describe('@Factory Annotation', function () {
 					}
 				}]);
 
-				ExampleClass = _Factory.Factory('MyFactory')(ExampleClass) || ExampleClass;
+				ExampleClass = (0, _factory.Factory)('MyFactory')(ExampleClass) || ExampleClass;
 				return ExampleClass;
 			})();
 
@@ -116,7 +116,7 @@ describe('@Factory Annotation', function () {
 				}
 
 				var _ExampleClass4 = ExampleClass;
-				ExampleClass = _Factory.Factory('MyFactory')(ExampleClass) || ExampleClass;
+				ExampleClass = (0, _factory.Factory)('MyFactory')(ExampleClass) || ExampleClass;
 				return ExampleClass;
 			})();
 

--- a/dist/annotations/inject.js
+++ b/dist/annotations/inject.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
 var _clone = require('clone');
 
-var _clone2 = _interopRequireWildcard(_clone);
+var _clone2 = _interopRequireDefault(_clone);
 
-var _annotate = require('../util/annotate');
+var _utilAnnotate = require('../util/annotate');
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var Inject = function Inject() {
 	for (var _len = arguments.length, dependencies = Array(_len), _key = 0; _key < _len; _key++) {
@@ -20,7 +20,7 @@ var Inject = function Inject() {
 	}
 
 	return function (t) {
-		_annotate2['default'](t, '$inject', dependencies);
+		(0, _utilAnnotate2['default'])(t, '$inject', dependencies);
 	};
 };
 exports.Inject = Inject;

--- a/dist/annotations/inject.spec.js
+++ b/dist/annotations/inject.spec.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Inject = require('./inject');
+var _inject = require('./inject');
 
-var _chai = require('../util/tests');
+var _utilTests = require('../util/tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _utilTests2 = _interopRequireDefault(_utilTests);
 
 describe('@Inject annotation', function () {
 	it('should decorate a function with the $inject array', function () {
@@ -20,7 +20,7 @@ describe('@Inject annotation', function () {
 			}
 
 			var _MyClass = MyClass;
-			MyClass = _Inject.Inject('a', 'b', 'c')(MyClass) || MyClass;
+			MyClass = (0, _inject.Inject)('a', 'b', 'c')(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -34,7 +34,7 @@ describe('@Inject annotation', function () {
 			}
 
 			var _MyClass2 = MyClass;
-			MyClass = _Inject.Inject('a', 'b', 'c')(MyClass) || MyClass;
+			MyClass = (0, _inject.Inject)('a', 'b', 'c')(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -48,7 +48,7 @@ describe('@Inject annotation', function () {
 			}
 
 			var _MyClass3 = MyClass;
-			MyClass = _Inject.Inject('a', 'b', 'c')(MyClass) || MyClass;
+			MyClass = (0, _inject.Inject)('a', 'b', 'c')(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -64,7 +64,7 @@ describe('@Inject annotation', function () {
 			_inherits(SubClass, _MyClass4);
 
 			var _SubClass = SubClass;
-			SubClass = _Inject.Inject('d', 'e', 'f')(SubClass) || SubClass;
+			SubClass = (0, _inject.Inject)('d', 'e', 'f')(SubClass) || SubClass;
 			return SubClass;
 		})(MyClass);
 

--- a/dist/annotations/provider.js
+++ b/dist/annotations/provider.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _Module = require('../module/module');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate = require('../util/annotate');
+var _moduleModule = require('../module/module');
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var type = 'provider';
 
 var Provider = function Provider(t) {
-	_annotate2['default'](t, '$provider', { name: t.name, type: type });
+	(0, _utilAnnotate2['default'])(t, '$provider', { name: t.name, type: type });
 };
 
 exports.Provider = Provider;
-_Module.Module.registerProvider(type, function (provider, module) {
+_moduleModule.Module.registerProvider(type, function (provider, module) {
 	module.provider(provider.$provider.name, provider);
 });

--- a/dist/annotations/require.js
+++ b/dist/annotations/require.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _annotate = require('../util/annotate');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var _clone = require('clone');
 
-var _clone2 = _interopRequireWildcard(_clone);
+var _clone2 = _interopRequireDefault(_clone);
 
 var Require = function Require() {
 	for (var _len = arguments.length, components = Array(_len), _key = 0; _key < _len; _key++) {
@@ -20,9 +20,9 @@ var Require = function Require() {
 	}
 
 	return function (t) {
-		_annotate2['default'](t, '$component', {});
-		_annotate2['default'](t.$component, 'require', components);
-		_annotate2['default'](t, 'unpackRequires', function unpackRequires(resolved) {
+		(0, _utilAnnotate2['default'])(t, '$component', {});
+		(0, _utilAnnotate2['default'])(t.$component, 'require', components);
+		(0, _utilAnnotate2['default'])(t, 'unpackRequires', function unpackRequires(resolved) {
 			var unpacked = {};
 
 			if (components.length > 1) {

--- a/dist/annotations/require.spec.js
+++ b/dist/annotations/require.spec.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
-
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _chai = require('../util/tests');
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _chai2 = _interopRequireWildcard(_chai);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Require = require('./require');
+var _utilTests = require('../util/tests');
+
+var _utilTests2 = _interopRequireDefault(_utilTests);
+
+var _require = require('./require');
 
 describe('@Require annotation for requiring directive controllers', function () {
 	it('should add $component meta data', function () {
@@ -22,7 +22,7 @@ describe('@Require annotation for requiring directive controllers', function () 
 			}
 
 			var _MyComponent = MyComponent;
-			MyComponent = _Require.Require('^parentCtrl', 'siblingCtrl')(MyComponent) || MyComponent;
+			MyComponent = (0, _require.Require)('^parentCtrl', 'siblingCtrl')(MyComponent) || MyComponent;
 			return MyComponent;
 		})();
 
@@ -50,7 +50,7 @@ describe('@Require annotation for requiring directive controllers', function () 
 				}
 			}]);
 
-			MyComponent = _Require.Require('^parentCtrl', 'siblingCtrl')(MyComponent) || MyComponent;
+			MyComponent = (0, _require.Require)('^parentCtrl', 'siblingCtrl')(MyComponent) || MyComponent;
 			return MyComponent;
 		})();
 
@@ -64,7 +64,7 @@ describe('@Require annotation for requiring directive controllers', function () 
 			}
 
 			var _Test = Test;
-			Test = _Require.Require('^parent')(Test) || Test;
+			Test = (0, _require.Require)('^parent')(Test) || Test;
 			return Test;
 		})();
 
@@ -80,7 +80,7 @@ describe('@Require annotation for requiring directive controllers', function () 
 			_inherits(NewTest, _Test2);
 
 			var _NewTest = NewTest;
-			NewTest = _Require.Require('sibling')(NewTest) || NewTest;
+			NewTest = (0, _require.Require)('sibling')(NewTest) || NewTest;
 			return NewTest;
 		})(Test);
 

--- a/dist/annotations/service.js
+++ b/dist/annotations/service.js
@@ -1,24 +1,24 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _Module = require('../module/module');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate = require('../util/annotate');
+var _moduleModule = require('../module/module');
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var type = 'service';
 
 var Service = function Service(t) {
-	_annotate2['default'](t, '$provider', { name: t.name, type: type });
+	(0, _utilAnnotate2['default'])(t, '$provider', { name: t.name, type: type });
 };
 
 exports.Service = Service;
-_Module.Module.registerProvider(type, function (provider, module) {
+_moduleModule.Module.registerProvider(type, function (provider, module) {
 	module.service(provider.$provider.name, provider);
 });

--- a/dist/annotations/service.spec.js
+++ b/dist/annotations/service.spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Module = require('../module/module');
+var _moduleModule = require('../module/module');
 
-var _Service = require('./service');
+var _service = require('./service');
 
-var _sinon = require('../util/tests');
+var _utilTests = require('../util/tests');
 
 describe('@Service Annotation', function () {
 	it('should annotate a class', function () {
@@ -18,7 +18,7 @@ describe('@Service Annotation', function () {
 			}
 
 			var _MyService = MyService;
-			MyService = _Service.Service(MyService) || MyService;
+			MyService = (0, _service.Service)(MyService) || MyService;
 			return MyService;
 		})();
 
@@ -34,7 +34,7 @@ describe('@Service Annotation', function () {
 			}
 
 			var _BaseClass = BaseClass;
-			BaseClass = _Service.Service(BaseClass) || BaseClass;
+			BaseClass = (0, _service.Service)(BaseClass) || BaseClass;
 			return BaseClass;
 		})();
 
@@ -50,7 +50,7 @@ describe('@Service Annotation', function () {
 			_inherits(MyClass, _BaseClass2);
 
 			var _MyClass = MyClass;
-			MyClass = _Service.Service(MyClass) || MyClass;
+			MyClass = (0, _service.Service)(MyClass) || MyClass;
 			return MyClass;
 		})(BaseClass);
 
@@ -63,9 +63,9 @@ describe('@Service Annotation', function () {
 		    module = undefined;
 
 		beforeEach(function () {
-			parser = _Module.Module.getParser('service');
+			parser = _moduleModule.Module.getParser('service');
 			module = {
-				service: _sinon.sinon.spy()
+				service: _utilTests.sinon.spy()
 			};
 		});
 
@@ -80,7 +80,7 @@ describe('@Service Annotation', function () {
 				}
 
 				var _MyService2 = MyService;
-				MyService = _Service.Service(MyService) || MyService;
+				MyService = (0, _service.Service)(MyService) || MyService;
 				return MyService;
 			})();
 

--- a/dist/annotations/template.js
+++ b/dist/annotations/template.js
@@ -1,19 +1,19 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _annotate = require('../util/annotate');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
+
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
 var Template = function Template() {
 	var options = arguments[0] === undefined ? {} : arguments[0];
 	return function (t) {
-		_annotate2['default'](t, '$component');
+		(0, _utilAnnotate2['default'])(t, '$component');
 
 		if (t.$component.templateUrl) {
 			delete t.$component.templateUrl;

--- a/dist/annotations/template.spec.js
+++ b/dist/annotations/template.spec.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Template = require('./template');
+var _template = require('./template');
 
-var _chai = require('../util/tests');
+var _utilTests = require('../util/tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _utilTests2 = _interopRequireDefault(_utilTests);
 
 describe('@Template Annotation', function () {
 	it('should add a template option to a component', function () {
@@ -20,7 +20,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass = MyClass;
-			MyClass = _Template.Template({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -35,7 +35,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass2 = MyClass;
-			MyClass = _Template.Template({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -49,7 +49,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass3 = MyClass;
-			MyClass = _Template.Template({ url: '/path/to/it' })(MyClass) || MyClass;
+			MyClass = (0, _template.Template)({ url: '/path/to/it' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -63,7 +63,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass4 = MyClass;
-			MyClass = _Template.Template({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -79,7 +79,7 @@ describe('@Template Annotation', function () {
 			_inherits(NewClass, _MyClass5);
 
 			var _NewClass = NewClass;
-			NewClass = _Template.Template({ url: '/path/to/it' })(NewClass) || NewClass;
+			NewClass = (0, _template.Template)({ url: '/path/to/it' })(NewClass) || NewClass;
 			return NewClass;
 		})(MyClass);
 
@@ -95,7 +95,7 @@ describe('@Template Annotation', function () {
 			_inherits(TestClass, _NewClass2);
 
 			var _TestClass = TestClass;
-			TestClass = _Template.Template({ inline: 'new test' })(TestClass) || TestClass;
+			TestClass = (0, _template.Template)({ inline: 'new test' })(TestClass) || TestClass;
 			return TestClass;
 		})(NewClass);
 

--- a/dist/annotations/transclude.js
+++ b/dist/annotations/transclude.js
@@ -1,28 +1,28 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _annotate = require('../util/annotate');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _utilAnnotate = require('../util/annotate');
 
-var _is = require('is-js');
+var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
-var _is2 = _interopRequireWildcard(_is);
+var _isJs = require('is-js');
+
+var _isJs2 = _interopRequireDefault(_isJs);
 
 var Transclude = function Transclude(t) {
-	if (_is2['default'].string(t)) {
+	if (_isJs2['default'].string(t)) {
 		return function (realT) {
-			_annotate2['default'](realT, '$component', {});
-			_annotate2['default'](realT.$component, 'transclude', t);
+			(0, _utilAnnotate2['default'])(realT, '$component', {});
+			(0, _utilAnnotate2['default'])(realT.$component, 'transclude', t);
 		};
 	} else {
-		_annotate2['default'](t, '$component', {});
-		_annotate2['default'](t.$component, 'transclude', true);
+		(0, _utilAnnotate2['default'])(t, '$component', {});
+		(0, _utilAnnotate2['default'])(t.$component, 'transclude', true);
 	}
 };
 exports.Transclude = Transclude;

--- a/dist/annotations/transclude.spec.js
+++ b/dist/annotations/transclude.spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _Transclude = require('./transclude');
+var _transclude = require('./transclude');
 
-var _chai = require('../util/tests');
+var _utilTests = require('../util/tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _utilTests2 = _interopRequireDefault(_utilTests);
 
 describe('@Transclude annotation', function () {
 	it('should decorate a function with the $component object', function () {
@@ -18,7 +18,7 @@ describe('@Transclude annotation', function () {
 			}
 
 			var _MyComponent = MyComponent;
-			MyComponent = _Transclude.Transclude(MyComponent) || MyComponent;
+			MyComponent = (0, _transclude.Transclude)(MyComponent) || MyComponent;
 			return MyComponent;
 		})();
 
@@ -32,7 +32,7 @@ describe('@Transclude annotation', function () {
 			}
 
 			var _MyClass = MyClass;
-			MyClass = _Transclude.Transclude(MyClass) || MyClass;
+			MyClass = (0, _transclude.Transclude)(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -46,7 +46,7 @@ describe('@Transclude annotation', function () {
 			}
 
 			var _MyComponent2 = MyComponent;
-			MyComponent = _Transclude.Transclude('element')(MyComponent) || MyComponent;
+			MyComponent = (0, _transclude.Transclude)('element')(MyComponent) || MyComponent;
 			return MyComponent;
 		})();
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,36 +4,36 @@ Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 
-var _Component = require('./annotations/component');
+var _annotationsComponent = require('./annotations/component');
 
-var _Controller = require('./annotations/controller');
+var _annotationsController = require('./annotations/controller');
 
-var _Decorator = require('./annotations/decorator');
+var _annotationsDecorator = require('./annotations/decorator');
 
-var _Factory = require('./annotations/factory');
+var _annotationsFactory = require('./annotations/factory');
 
-var _Inject = require('./annotations/inject');
+var _annotationsInject = require('./annotations/inject');
 
-var _Provider = require('./annotations/provider');
+var _annotationsProvider = require('./annotations/provider');
 
-var _Require = require('./annotations/require');
+var _annotationsRequire = require('./annotations/require');
 
-var _Service = require('./annotations/service');
+var _annotationsService = require('./annotations/service');
 
-var _Template = require('./annotations/template');
+var _annotationsTemplate = require('./annotations/template');
 
-var _Transclude = require('./annotations/transclude');
+var _annotationsTransclude = require('./annotations/transclude');
 
-var _Module = require('./module/module');
+var _moduleModule = require('./module/module');
 
-exports.Component = _Component.Component;
-exports.Controller = _Controller.Controller;
-exports.Decorator = _Decorator.Decorator;
-exports.Factory = _Factory.Factory;
-exports.Inject = _Inject.Inject;
-exports.Provider = _Provider.Provider;
-exports.Require = _Require.Require;
-exports.Service = _Service.Service;
-exports.Template = _Template.Template;
-exports.Transclude = _Transclude.Transclude;
-exports.Module = _Module.Module;
+exports.Component = _annotationsComponent.Component;
+exports.Controller = _annotationsController.Controller;
+exports.Decorator = _annotationsDecorator.Decorator;
+exports.Factory = _annotationsFactory.Factory;
+exports.Inject = _annotationsInject.Inject;
+exports.Provider = _annotationsProvider.Provider;
+exports.Require = _annotationsRequire.Require;
+exports.Service = _annotationsService.Service;
+exports.Template = _annotationsTemplate.Template;
+exports.Transclude = _annotationsTransclude.Transclude;
+exports.Module = _moduleModule.Module;

--- a/dist/index.spec.js
+++ b/dist/index.spec.js
@@ -1,45 +1,45 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
-var _chai = require('./util/tests');
+var _utilTests = require('./util/tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _utilTests2 = _interopRequireDefault(_utilTests);
 
-var _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module = require('./index');
+var _index = require('./index');
 
 describe('Angular Decorators', function () {
 	it('should export Component', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Component.should.be.defined;
+		return _index.Component.should.be.defined;
 	});
 	it('should export Controller', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Controller.should.be.defined;
+		return _index.Controller.should.be.defined;
 	});
 	it('should export Decorator', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Decorator.should.be.defined;
+		return _index.Decorator.should.be.defined;
 	});
 	it('should export Factory', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Factory.should.be.defined;
+		return _index.Factory.should.be.defined;
 	});
 	it('should export Inject', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Inject.should.be.defined;
+		return _index.Inject.should.be.defined;
 	});
 	it('should export Provider', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Provider.should.be.defined;
+		return _index.Provider.should.be.defined;
 	});
 	it('should export Require', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Require.should.be.defined;
+		return _index.Require.should.be.defined;
 	});
 	it('should export Service', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Service.should.be.defined;
+		return _index.Service.should.be.defined;
 	});
 	it('should export Template', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Template.should.be.defined;
+		return _index.Template.should.be.defined;
 	});
 	it('should export Transclude', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Transclude.should.be.defined;
+		return _index.Transclude.should.be.defined;
 	});
 	it('should export Module', function () {
-		return _Component$Controller$Decorator$Factory$Inject$Provider$Require$Service$Template$Transclude$Module.Module.should.be.defined;
+		return _index.Module.should.be.defined;
 	});
 });

--- a/dist/module/module.js
+++ b/dist/module/module.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _bind = Function.prototype.bind;
-
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
-
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
+var _bind = Function.prototype.bind;
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
 var _parsers = {};
 
 var DecoratedModule = (function () {

--- a/dist/util/annotate.js
+++ b/dist/util/annotate.js
@@ -1,49 +1,49 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
-var _toConsumableArray = function (arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 exports['default'] = annotate;
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
+
 var _clone = require('clone');
 
-var _clone2 = _interopRequireWildcard(_clone);
+var _clone2 = _interopRequireDefault(_clone);
 
 var _extend = require('extend');
 
-var _extend2 = _interopRequireWildcard(_extend);
+var _extend2 = _interopRequireDefault(_extend);
 
-var _is = require('is-js');
+var _isJs = require('is-js');
 
-var _is2 = _interopRequireWildcard(_is);
+var _isJs2 = _interopRequireDefault(_isJs);
 
 function install(obj, property, base) {
-	obj[property] = obj[property] ? _clone2['default'](obj[property]) : base;
+	obj[property] = obj[property] ? (0, _clone2['default'])(obj[property]) : base;
 }
 
 function annotate(obj, property) {
 	var value = arguments[2] === undefined ? {} : arguments[2];
 
-	if (_is2['default'].array(value)) {
+	if (_isJs2['default'].array(value)) {
 		var _obj$property;
 
 		install(obj, property, []);
 
 		(_obj$property = obj[property]).push.apply(_obj$property, _toConsumableArray(value));
-	} else if (_is2['default'].string(value)) {
+	} else if (_isJs2['default'].string(value)) {
 		obj[property] = value;
-	} else if (_is2['default'].fn(value)) {
+	} else if (_isJs2['default'].fn(value)) {
 		obj[property] = value;
-	} else if (_is2['default'].bool(value)) {
+	} else if (_isJs2['default'].bool(value)) {
 		obj[property] = value;
-	} else if (_is2['default'].object(value)) {
+	} else if (_isJs2['default'].object(value)) {
 		install(obj, property, {});
 
-		_extend2['default'](true, obj[property], value);
+		(0, _extend2['default'])(true, obj[property], value);
 	}
 }
 

--- a/dist/util/decorate-directive.js
+++ b/dist/util/decorate-directive.js
@@ -13,7 +13,7 @@ var _annotate = require('./annotate');
 
 var _annotate2 = _interopRequireDefault(_annotate);
 
-function decorateDirective(t, name, restrict, scope) {
+function decorateDirective(t, name, restrict, scope, controllerAs) {
 	(0, _annotate2['default'])(t, '$provider', {
 		name: name,
 		type: 'directive'
@@ -24,6 +24,10 @@ function decorateDirective(t, name, restrict, scope) {
 	if (scope) {
 		(0, _annotate2['default'])(t, '$component', { bindToController: true });
 		(0, _annotate2['default'])(t.$component, 'scope', scope);
+	}
+
+	if (controllerAs) {
+		(0, _annotate2['default'])(t.$component, 'controllerAs', controllerAs);
 	}
 }
 

--- a/dist/util/decorate-directive.js
+++ b/dist/util/decorate-directive.js
@@ -1,33 +1,33 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 exports.decorateDirective = decorateDirective;
 
-var _Module = require('../module/module');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _moduleModule = require('../module/module');
 
 var _annotate = require('./annotate');
 
-var _annotate2 = _interopRequireWildcard(_annotate);
+var _annotate2 = _interopRequireDefault(_annotate);
 
 function decorateDirective(t, name, restrict, scope) {
-	_annotate2['default'](t, '$provider', {
+	(0, _annotate2['default'])(t, '$provider', {
 		name: name,
 		type: 'directive'
 	});
 
-	_annotate2['default'](t, '$component', { restrict: restrict });
+	(0, _annotate2['default'])(t, '$component', { restrict: restrict });
 
 	if (scope) {
-		_annotate2['default'](t, '$component', { bindToController: true });
-		_annotate2['default'](t.$component, 'scope', scope);
+		(0, _annotate2['default'])(t, '$component', { bindToController: true });
+		(0, _annotate2['default'])(t.$component, 'scope', scope);
 	}
 }
 
-_Module.Module.registerProvider('directive', function (provider, module) {
+_moduleModule.Module.registerProvider('directive', function (provider, module) {
 	var name = provider.$provider.name;
 	var controller = provider;
 	var component = controller.$component;

--- a/dist/util/decorate-directive.spec.js
+++ b/dist/util/decorate-directive.spec.js
@@ -2,19 +2,19 @@
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _inherits = function (subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; };
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var _decorateDirective = require('./decorate-directive');
 
-var _Module = require('../module/module');
+var _moduleModule = require('../module/module');
 
-var _sinon = require('./tests');
+var _tests = require('./tests');
 
 var Decorate = function Decorate(name, type, binder) {
 	return function (t) {
-		_decorateDirective.decorateDirective(t, name, type, binder);
+		(0, _decorateDirective.decorateDirective)(t, name, type, binder);
 	};
 };
 
@@ -24,7 +24,7 @@ describe('Directive decorator', function () {
 			_classCallCheck(this, Example);
 		};
 
-		_decorateDirective.decorateDirective(Example, 'test', 'E');
+		(0, _decorateDirective.decorateDirective)(Example, 'test', 'E');
 
 		Example.should.have.property('$component');
 		Example.should.have.property('$provider');
@@ -38,7 +38,7 @@ describe('Directive decorator', function () {
 			_classCallCheck(this, Example);
 		};
 
-		_decorateDirective.decorateDirective(Example, 'test', 'E', { myAttr: '=' });
+		(0, _decorateDirective.decorateDirective)(Example, 'test', 'E', { 'myAttr': '=' });
 
 		Example.$component.should.have.property('scope');
 		Example.$component.scope.should.have.property('myAttr', '=');
@@ -49,7 +49,7 @@ describe('Directive decorator', function () {
 			_classCallCheck(this, Example);
 		};
 
-		_decorateDirective.decorateDirective(Example, 'test', 'E', { myAttr: '=' });
+		(0, _decorateDirective.decorateDirective)(Example, 'test', 'E', { 'myAttr': '=' });
 
 		Example.$component.should.have.property('bindToController', true);
 	});
@@ -59,7 +59,7 @@ describe('Directive decorator', function () {
 			_classCallCheck(this, Example);
 		};
 
-		_decorateDirective.decorateDirective(Example, 'test', 'E', { myAttr: '=' });
+		(0, _decorateDirective.decorateDirective)(Example, 'test', 'E', { 'myAttr': '=' });
 
 		var NewExample = (function (_Example) {
 			function NewExample() {
@@ -75,7 +75,7 @@ describe('Directive decorator', function () {
 			return NewExample;
 		})(Example);
 
-		_decorateDirective.decorateDirective(NewExample, 'test', 'A', { newAttr: '&' });
+		(0, _decorateDirective.decorateDirective)(NewExample, 'test', 'A', { 'newAttr': '&' });
 
 		Example.$component.scope.should.eql({
 			myAttr: '='
@@ -119,15 +119,15 @@ describe('Directive decorator', function () {
 
 	describe('parser', function () {
 		it('should be registered with Module', function () {
-			var parser = _Module.Module.getParser('directive');
+			var parser = _moduleModule.Module.getParser('directive');
 
 			parser.should.be.defined;
 		});
 
 		it('should register a directive on a module', function () {
-			var parser = _Module.Module.getParser('directive');
+			var parser = _moduleModule.Module.getParser('directive');
 			var module = {
-				directive: _sinon.sinon.spy()
+				directive: _tests.sinon.spy()
 			};
 
 			var MyComponent = (function () {
@@ -146,7 +146,7 @@ describe('Directive decorator', function () {
 				return MyComponent;
 			})();
 
-			_decorateDirective.decorateDirective(MyComponent, 'myComponent', 'E', { myAttr: '=' });
+			(0, _decorateDirective.decorateDirective)(MyComponent, 'myComponent', 'E', { 'myAttr': '=' });
 
 			parser(MyComponent, module);
 
@@ -160,7 +160,7 @@ describe('Directive decorator', function () {
 			directive.should.eql({
 				restrict: 'E',
 				bindToController: true,
-				scope: { myAttr: '=' },
+				scope: { 'myAttr': '=' },
 				link: MyComponent.link,
 				controller: controller,
 				compile: MyComponent.compile,
@@ -169,9 +169,9 @@ describe('Directive decorator', function () {
 		});
 
 		it('should allow for a static link function on the class', function () {
-			var parser = _Module.Module.getParser('directive');
+			var parser = _moduleModule.Module.getParser('directive');
 			var module = {
-				directive: _sinon.sinon.spy()
+				directive: _tests.sinon.spy()
 			};
 			var testLink = false;
 
@@ -190,7 +190,7 @@ describe('Directive decorator', function () {
 				return MyComponent;
 			})();
 
-			_decorateDirective.decorateDirective(MyComponent, 'myComponent', 'E', {});
+			(0, _decorateDirective.decorateDirective)(MyComponent, 'myComponent', 'E', {});
 			parser(MyComponent, module);
 
 			var directive = module.directive.args[0][1]();

--- a/dist/util/decorate-directive.spec.js
+++ b/dist/util/decorate-directive.spec.js
@@ -54,6 +54,16 @@ describe('Directive decorator', function () {
 		Example.$component.should.have.property('bindToController', true);
 	});
 
+	it('should set controllerAs parameter if provided', function () {
+		var Example = function Example() {
+			_classCallCheck(this, Example);
+		};
+
+		(0, _decorateDirective.decorateDirective)(Example, 'test', 'E', {}, 'exampleController');
+
+		Example.$component.should.have.property('controllerAs', 'exampleController');
+	});
+
 	it('should merge binders if used on a subclass', function () {
 		var Example = function Example() {
 			_classCallCheck(this, Example);
@@ -146,7 +156,7 @@ describe('Directive decorator', function () {
 				return MyComponent;
 			})();
 
-			(0, _decorateDirective.decorateDirective)(MyComponent, 'myComponent', 'E', { 'myAttr': '=' });
+			(0, _decorateDirective.decorateDirective)(MyComponent, 'myComponent', 'E', { 'myAttr': '=' }, 'MyComponentController');
 
 			parser(MyComponent, module);
 
@@ -164,7 +174,7 @@ describe('Directive decorator', function () {
 				link: MyComponent.link,
 				controller: controller,
 				compile: MyComponent.compile,
-				controllerAs: 'MyComponent'
+				controllerAs: 'MyComponentController'
 			});
 		});
 

--- a/dist/util/parse-component-selector.js
+++ b/dist/util/parse-component-selector.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _toConsumableArray = function (arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } };
-
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
 exports.parseComponentSelector = parseComponentSelector;
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
 
 function parseComponentSelector(selector) {
 	var selectorArray = undefined;

--- a/dist/util/parse-component-selector.spec.js
+++ b/dist/util/parse-component-selector.spec.js
@@ -1,34 +1,34 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 var _parseComponentSelector = require('./parse-component-selector');
 
-var _chai = require('./tests');
+var _tests = require('./tests');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _tests2 = _interopRequireDefault(_tests);
 
 describe('Component selector parser', function () {
 	it('should correctly parse element selectors', function () {
-		var info = _parseComponentSelector.parseComponentSelector('my-component-selector');
+		var info = (0, _parseComponentSelector.parseComponentSelector)('my-component-selector');
 
 		info.should.have.property('name', 'myComponentSelector');
 		info.should.have.property('type', 'E');
 
-		info = _parseComponentSelector.parseComponentSelector('component');
+		info = (0, _parseComponentSelector.parseComponentSelector)('component');
 
 		info.name.should.equal('component');
 	});
 
 	it('should correctly parse attribute selectors', function () {
-		var info = _parseComponentSelector.parseComponentSelector('[my-attr]');
+		var info = (0, _parseComponentSelector.parseComponentSelector)('[my-attr]');
 
 		info.name.should.equal('myAttr');
 		info.type.should.equal('A');
 	});
 
 	it('should correctly parse class selectors', function () {
-		var info = _parseComponentSelector.parseComponentSelector('.my-class');
+		var info = (0, _parseComponentSelector.parseComponentSelector)('.my-class');
 
 		info.name.should.equal('myClass');
 		info.type.should.equal('C');

--- a/dist/util/tests.js
+++ b/dist/util/tests.js
@@ -1,22 +1,22 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
-
 Object.defineProperty(exports, '__esModule', {
   value: true
 });
 
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
 var _chai = require('chai');
 
-var _chai2 = _interopRequireWildcard(_chai);
+var _chai2 = _interopRequireDefault(_chai);
 
 var _sinonChai = require('sinon-chai');
 
-var _sinonChai2 = _interopRequireWildcard(_sinonChai);
+var _sinonChai2 = _interopRequireDefault(_sinonChai);
 
 var _sinon = require('sinon');
 
-var _sinon2 = _interopRequireWildcard(_sinon);
+var _sinon2 = _interopRequireDefault(_sinon);
 
 _chai2['default'].use(_sinonChai2['default']);
 

--- a/src/annotations/component.js
+++ b/src/annotations/component.js
@@ -5,7 +5,7 @@ export const Component = options => t => {
 	if(! options.selector ) throw new Error('Must provide a selector')
 	let info = parseComponentSelector(options.selector);
 
-	decorateDirective(t, info.name, info.type, options.bind);
+	decorateDirective(t, info.name, info.type, options.bind, options.controllerAs);
 
 	if(info.type !== 'E')
 	{

--- a/src/util/decorate-directive.js
+++ b/src/util/decorate-directive.js
@@ -1,7 +1,7 @@
 import {Module} from '../module/module';
 import annotate from './annotate';
 
-export function decorateDirective(t, name, restrict, scope){
+export function decorateDirective(t, name, restrict, scope, controllerAs){
 	annotate(t, '$provider', {
 		name,
 		type : 'directive'
@@ -12,6 +12,10 @@ export function decorateDirective(t, name, restrict, scope){
 	if(scope){
 		annotate(t, '$component', { bindToController : true });
 		annotate(t.$component, 'scope', scope);
+	}
+	
+	if(controllerAs) {
+		annotate(t.$component, 'controllerAs', controllerAs);
 	}
 }
 

--- a/src/util/decorate-directive.spec.js
+++ b/src/util/decorate-directive.spec.js
@@ -36,6 +36,14 @@ describe('Directive decorator', function(){
 		Example.$component.should.have.property('bindToController', true);
 	});
 
+	it('should set controllerAs parameter if provided', function(){
+		class Example{ }
+
+                decorateDirective(Example, 'test', 'E', { }, 'exampleController');
+
+                Example.$component.should.have.property('controllerAs', 'exampleController');
+	});
+
 	it('should merge binders if used on a subclass', function(){
 		class Example{ }
 		decorateDirective(Example, 'test', 'E', { 'myAttr' : '=' });
@@ -85,7 +93,7 @@ describe('Directive decorator', function(){
 
 				}
 			}
-			decorateDirective(MyComponent, 'myComponent', 'E', { 'myAttr' : '=' });
+			decorateDirective(MyComponent, 'myComponent', 'E', { 'myAttr' : '=' }, 'MyComponentController');
 
 			parser(MyComponent, module);
 
@@ -103,7 +111,7 @@ describe('Directive decorator', function(){
 				link : MyComponent.link,
 				controller : controller,
 				compile : MyComponent.compile,
-				controllerAs: 'MyComponent'
+				controllerAs: 'MyComponentController'
 			});
 		});
 


### PR DESCRIPTION
I've added additional parameter named 'controllerAs' which is possible to use with Component annotation.

Why this could be beneficial? Imagine you have a project with large number of already created directives.  Inside your directives you are already using 'controllerAs' syntax. But it turned out that value of 'controllerAs' inside your directives is not the same as added by Component annotation by default. 

Then, if you decide to switch to usage of "angular-decorators", you have to redefine all the templates of directives you have. This was exactly my case, that's why I've added support of 'controllerAs' to Component annotation.

P.S. Don't worry about too many files changed. This is because of upgrade of babel in latest versions. It now transpiles source code in a bit another way. So, entire 'dist/' folder was overwritten.
