### PR TITLE
Change Template annotation to View annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ let myModule = Module('my-component-module', []);
 	controllerAs : 'vm',
 	bind : { 'myAttrA' : '=', 'myAttrB' : '&' }
 })
-@Template({ url : '/path/to/template.html' })
+@View({ templateUrl : '/path/to/template.html' })
 @Require('requiredComponent')
 @Inject('$element', '$attrs')
 class MyComponentCtrl{

--- a/dist/annotations/controller.spec.js
+++ b/dist/annotations/controller.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
@@ -75,9 +77,7 @@ describe('@Controller annotation', function () {
 			function NewController() {
 				_classCallCheck(this, _NewController);
 
-				if (_MyController4 != null) {
-					_MyController4.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_NewController.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(NewController, _MyController4);

--- a/dist/annotations/inject.spec.js
+++ b/dist/annotations/inject.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
@@ -56,9 +58,7 @@ describe('@Inject annotation', function () {
 			function SubClass() {
 				_classCallCheck(this, _SubClass);
 
-				if (_MyClass4 != null) {
-					_MyClass4.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_SubClass.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(SubClass, _MyClass4);

--- a/dist/annotations/require.spec.js
+++ b/dist/annotations/require.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -72,9 +74,7 @@ describe('@Require annotation for requiring directive controllers', function () 
 			function NewTest() {
 				_classCallCheck(this, _NewTest);
 
-				if (_Test2 != null) {
-					_Test2.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_NewTest.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(NewTest, _Test2);

--- a/dist/annotations/service.spec.js
+++ b/dist/annotations/service.spec.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
@@ -42,9 +44,7 @@ describe('@Service Annotation', function () {
 			function MyClass() {
 				_classCallCheck(this, _MyClass);
 
-				if (_BaseClass2 != null) {
-					_BaseClass2.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_MyClass.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(MyClass, _BaseClass2);

--- a/dist/annotations/view.js
+++ b/dist/annotations/view.js
@@ -10,7 +10,7 @@ var _utilAnnotate = require('../util/annotate');
 
 var _utilAnnotate2 = _interopRequireDefault(_utilAnnotate);
 
-var Template = function Template() {
+var View = function View() {
 	var options = arguments[0] === undefined ? {} : arguments[0];
 	return function (t) {
 		(0, _utilAnnotate2['default'])(t, '$component');
@@ -22,11 +22,11 @@ var Template = function Template() {
 			delete t.$component.template;
 		}
 
-		if (options.url) {
-			t.$component.templateUrl = options.url;
-		} else if (options.inline) {
-			t.$component.template = options.inline;
+		if (options.templateUrl) {
+			t.$component.templateUrl = options.templateUrl;
+		} else if (options.template) {
+			t.$component.template = options.template;
 		}
 	};
 };
-exports.Template = Template;
+exports.View = View;

--- a/dist/annotations/view.spec.js
+++ b/dist/annotations/view.spec.js
@@ -1,18 +1,20 @@
 'use strict';
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-var _template = require('./template');
+var _view = require('./view');
 
 var _utilTests = require('../util/tests');
 
 var _utilTests2 = _interopRequireDefault(_utilTests);
 
-describe('@Template Annotation', function () {
+describe('@View Annotation', function () {
 	it('should add a template option to a component', function () {
 		var MyClass = (function () {
 			function MyClass() {
@@ -20,7 +22,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass = MyClass;
-			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _view.View)({ template: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -35,7 +37,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass2 = MyClass;
-			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _view.View)({ template: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -49,7 +51,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass3 = MyClass;
-			MyClass = (0, _template.Template)({ url: '/path/to/it' })(MyClass) || MyClass;
+			MyClass = (0, _view.View)({ templateUrl: '/path/to/it' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -63,7 +65,7 @@ describe('@Template Annotation', function () {
 			}
 
 			var _MyClass4 = MyClass;
-			MyClass = (0, _template.Template)({ inline: 'test' })(MyClass) || MyClass;
+			MyClass = (0, _view.View)({ template: 'test' })(MyClass) || MyClass;
 			return MyClass;
 		})();
 
@@ -71,15 +73,13 @@ describe('@Template Annotation', function () {
 			function NewClass() {
 				_classCallCheck(this, _NewClass);
 
-				if (_MyClass5 != null) {
-					_MyClass5.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_NewClass.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(NewClass, _MyClass5);
 
 			var _NewClass = NewClass;
-			NewClass = (0, _template.Template)({ url: '/path/to/it' })(NewClass) || NewClass;
+			NewClass = (0, _view.View)({ templateUrl: '/path/to/it' })(NewClass) || NewClass;
 			return NewClass;
 		})(MyClass);
 
@@ -87,15 +87,13 @@ describe('@Template Annotation', function () {
 			function TestClass() {
 				_classCallCheck(this, _TestClass);
 
-				if (_NewClass2 != null) {
-					_NewClass2.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_TestClass.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(TestClass, _NewClass2);
 
 			var _TestClass = TestClass;
-			TestClass = (0, _template.Template)({ inline: 'new test' })(TestClass) || TestClass;
+			TestClass = (0, _view.View)({ template: 'new test' })(TestClass) || TestClass;
 			return TestClass;
 		})(NewClass);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -20,7 +20,7 @@ var _annotationsRequire = require('./annotations/require');
 
 var _annotationsService = require('./annotations/service');
 
-var _annotationsTemplate = require('./annotations/template');
+var _annotationsView = require('./annotations/view');
 
 var _annotationsTransclude = require('./annotations/transclude');
 
@@ -34,6 +34,6 @@ exports.Inject = _annotationsInject.Inject;
 exports.Provider = _annotationsProvider.Provider;
 exports.Require = _annotationsRequire.Require;
 exports.Service = _annotationsService.Service;
-exports.Template = _annotationsTemplate.Template;
+exports.View = _annotationsView.View;
 exports.Transclude = _annotationsTransclude.Transclude;
 exports.Module = _moduleModule.Module;

--- a/dist/index.spec.js
+++ b/dist/index.spec.js
@@ -33,8 +33,8 @@ describe('Angular Decorators', function () {
 	it('should export Service', function () {
 		return _index.Service.should.be.defined;
 	});
-	it('should export Template', function () {
-		return _index.Template.should.be.defined;
+	it('should export View', function () {
+		return _index.View.should.be.defined;
 	});
 	it('should export Transclude', function () {
 		return _index.Transclude.should.be.defined;

--- a/dist/util/decorate-directive.spec.js
+++ b/dist/util/decorate-directive.spec.js
@@ -2,6 +2,8 @@
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
@@ -75,9 +77,7 @@ describe('Directive decorator', function () {
 			function NewExample() {
 				_classCallCheck(this, NewExample);
 
-				if (_Example != null) {
-					_Example.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(NewExample.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(NewExample, _Example);
@@ -112,9 +112,7 @@ describe('Directive decorator', function () {
 			function NewComponent() {
 				_classCallCheck(this, _NewComponent);
 
-				if (_BaseComponent2 != null) {
-					_BaseComponent2.apply(this, arguments);
-				}
+				_get(Object.getPrototypeOf(_NewComponent.prototype), 'constructor', this).apply(this, arguments);
 			}
 
 			_inherits(NewComponent, _BaseComponent2);

--- a/src/annotations/view.js
+++ b/src/annotations/view.js
@@ -1,6 +1,6 @@
 import annotate from '../util/annotate';
 
-export const Template = ( options = {} ) => t => {
+export const View = ( options = {} ) => t => {
 	annotate(t, '$component');
 
 	if(t.$component.templateUrl)
@@ -12,12 +12,12 @@ export const Template = ( options = {} ) => t => {
 		delete t.$component.template;
 	}
 
-	if(options.url)
+	if(options.templateUrl)
 	{
-		t.$component.templateUrl = options.url;
+		t.$component.templateUrl = options.templateUrl;
 	}
-	else if(options.inline)
+	else if(options.template)
 	{
-		t.$component.template = options.inline;
+		t.$component.template = options.template;
 	}
 }

--- a/src/annotations/view.spec.js
+++ b/src/annotations/view.spec.js
@@ -1,9 +1,9 @@
-import {Template} from './template';
+import {View} from './view';
 import chai from '../util/tests';
 
-describe('@Template Annotation', function(){
+describe('@View Annotation', function(){
 	it('should add a template option to a component', function(){
-		@Template({ inline : 'test' })
+		@View({ template : 'test' })
 		class MyClass{ }
 
 		MyClass.should.have.property('$component');
@@ -11,27 +11,27 @@ describe('@Template Annotation', function(){
 	});
 
 	it('should support inline templates', function(){
-		@Template({ inline : 'test' })
+		@View({ template : 'test' })
 		class MyClass{ }
 
 		MyClass.$component.should.have.property('template', 'test');
 	});
 
 	it('should support template URLs', function(){
-		@Template({ url : '/path/to/it' })
+		@View({ templateUrl : '/path/to/it' })
 		class MyClass{ }
 
 		MyClass.$component.should.have.property('templateUrl', '/path/to/it');
 	});
 
 	it('should overwrite previously set template options via inheritance', function(){
-		@Template({ inline : 'test' })
+		@View({ template : 'test' })
 		class MyClass{ }
 
-		@Template({ url : '/path/to/it' })
+		@View({ templateUrl : '/path/to/it' })
 		class NewClass extends MyClass{ }
 
-		@Template({ inline : 'new test' })
+		@View({ template : 'new test' })
 		class TestClass extends NewClass{ }
 
 		MyClass.$component.should.have.property('template', 'test');

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { Inject } from './annotations/inject';
 import { Provider } from './annotations/provider';
 import { Require } from './annotations/require';
 import { Service } from './annotations/service';
-import { Template } from './annotations/template';
+import { View } from './annotations/view';
 import { Transclude } from './annotations/transclude';
 import { Module } from './module/module';
 
@@ -19,7 +19,7 @@ export {
 	Provider,
 	Require,
 	Service,
-	Template,
+	View,
 	Transclude,
 	Module
 };

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -8,7 +8,7 @@ import {
 	Provider,
 	Require,
 	Service,
-	Template,
+	View,
 	Transclude,
 	Module
 } from './index';
@@ -22,7 +22,7 @@ describe('Angular Decorators', function(){
 	it('should export Provider', () => Provider.should.be.defined);
 	it('should export Require', () => Require.should.be.defined );
 	it('should export Service', () => Service.should.be.defined );
-	it('should export Template', () => Template.should.be.defined );
+	it('should export View', () => View.should.be.defined );
 	it('should export Transclude', () => Transclude.should.be.defined );
 	it('should export Module', () => Module.should.be.defined );
 });


### PR DESCRIPTION
It maybe reasonable to change Template annotation to View annotation as Angular2 now uses View annotation. So we'll be closer to Angular syntax.

For reference, look at https://angular.io/docs/js/latest/guide/setup.html.
